### PR TITLE
feat(category): implement cache for Category operations

### DIFF
--- a/product-service/src/main/java/com/rahman/productservice/dto/category/UpdateCategoryRequest.java
+++ b/product-service/src/main/java/com/rahman/productservice/dto/category/UpdateCategoryRequest.java
@@ -1,11 +1,15 @@
 package com.rahman.productservice.dto.category;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
 public record UpdateCategoryRequest(
         @Size(min = 1, max = 100, message = "{category.name.size}")
+        @NotBlank(message = "{category.name.not_blank}")
+        @NotNull(message = "{category.name.not_blank}")
         String name,
         @Size(min = 1, message = "{category.description.size}")
         String description,

--- a/product-service/src/main/java/com/rahman/productservice/entity/Category.java
+++ b/product-service/src/main/java/com/rahman/productservice/entity/Category.java
@@ -10,7 +10,6 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 import java.util.LinkedHashSet;
@@ -21,7 +20,6 @@ import java.util.UUID;
 @Setter
 @Entity
 @Table(name = "category")
-@EntityListeners(AuditingEntityListener.class)
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerIntegrationTest.java
+++ b/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerIntegrationTest.java
@@ -1,0 +1,328 @@
+package com.rahman.productservice.controller;
+
+
+import com.rahman.commonlib.ApiResponse;
+import com.rahman.productservice.ProductServiceApplication;
+import com.rahman.productservice.dto.category.CategoryResponse;
+import com.rahman.productservice.dto.category.CreateCategoryRequest;
+import com.rahman.productservice.dto.category.UpdateCategoryRequest;
+import com.rahman.productservice.entity.Category;
+import com.rahman.productservice.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        classes = ProductServiceApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "spring.cloud.config.fail-fast=false",
+                "spring.cloud.discovery.enabled=false",
+                "eureka.client.enabled=false"
+        }
+)
+@ActiveProfiles("test")
+class CategoryControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/category";
+
+        // Prepare test data
+        Category category1 = new Category();
+        category1.setName("Electronics");
+
+        Category category2 = new Category();
+        category2.setName("Hobbies");
+
+        List<Category> categories = List.of(category1, category2);
+        categoryRepository.saveAll(categories);
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testFindAllCategories_ReturnsList() {
+
+        // Perform GET request
+        ResponseEntity<ApiResponse<List<CategoryResponse>>> response = restTemplate.exchange(
+                baseUrl,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Basic check
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("success");
+        assertThat(response.getBody().data()).hasSize(2);
+        assertThat(response.getBody().data())
+                .extracting(CategoryResponse::name)
+                .containsExactlyInAnyOrder("Electronics", "Hobbies");
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testFindAllCategories_WhenNoCategoriesExist_ReturnsEmptyList() {
+        // Pastikan database kosong
+        categoryRepository.deleteAll();
+
+        // Lakukan GET request ke endpoint
+        ResponseEntity<ApiResponse<List<CategoryResponse>>> response = restTemplate.exchange(
+                baseUrl,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("success");
+        assertThat(response.getBody().data()).isNotNull();
+        assertThat(response.getBody().data()).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testSaveCategory_ReturnsSuccess() {
+        CreateCategoryRequest request = new CreateCategoryRequest("Finance", "Financial", null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<CreateCategoryRequest> entity = new HttpEntity<>(request, headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl,
+                HttpMethod.POST,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("success");
+        assertThat(response.getBody().data()).isNotNull();
+        assertThat(response.getBody().data().name()).isEqualTo("Finance");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testSaveCategory_WhenNameIsBlank_ReturnsBadRequest() {
+        CreateCategoryRequest request = new CreateCategoryRequest("", "Financial", null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<CreateCategoryRequest> entity = new HttpEntity<>(request, headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl,
+                HttpMethod.POST,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isFalse();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("name: Category name is required");
+        assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteCategory_Success() {
+
+        //Prepare data
+        Category category = new Category();
+        category.setName("Top Up & Tagihan");
+
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity entity = new HttpEntity<>(headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl + "/" +  id,
+                HttpMethod.DELETE,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("success");
+        assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteCategory_NotFound() {
+
+        UUID id = UUID.randomUUID();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity entity = new HttpEntity<>(headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl + "/" +  id,
+                HttpMethod.DELETE,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isFalse();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("Category not found.");
+        assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateCategory_ReturnsSuccess() {
+
+        //Prepare data
+        Category category = new Category();
+        category.setName("Electronics");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Hobbies", "Hobby and Toys", null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<UpdateCategoryRequest> entity = new HttpEntity<>(request, headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl + "/" +  id,
+                HttpMethod.PATCH,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("success");
+        assertThat(response.getBody().data()).isNotNull();
+        assertThat(response.getBody().data().name()).isEqualTo("Hobbies");
+        assertThat(response.getBody().data().description()).isEqualTo("Hobby and Toys");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateCategory_WhenNameIsBlank_ReturnsBadRequest() {
+        //Prepare data
+        Category category = new Category();
+        category.setName("Makeup");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+        UpdateCategoryRequest request = new UpdateCategoryRequest("", null, null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<UpdateCategoryRequest> entity = new HttpEntity<>(request, headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl + "/" +  id,
+                HttpMethod.PATCH,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isFalse();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).contains("name: Category name is required");
+        assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateCategory_NotFound() {
+
+        UUID id = UUID.randomUUID();
+
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Hobbies", "Hobby and Toys", null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<UpdateCategoryRequest> entity = new HttpEntity<>(request, headers);
+
+        // Execute
+        ResponseEntity<ApiResponse<CategoryResponse>> response = restTemplate.exchange(
+                baseUrl + "/" +  id,
+                HttpMethod.PATCH,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        // Validasi response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isFalse();
+        assertThat(response.getBody().message()).isNotEmpty();
+        assertThat(response.getBody().message()).isEqualTo("Category not found.");
+        assertThat(response.getBody().data()).isNull();
+    }
+}

--- a/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerSecuredTest.java
+++ b/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerSecuredTest.java
@@ -1,0 +1,138 @@
+package com.rahman.productservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rahman.productservice.ProductServiceApplication;
+import com.rahman.productservice.dto.category.CreateCategoryRequest;
+import com.rahman.productservice.dto.category.UpdateCategoryRequest;
+import com.rahman.productservice.entity.Category;
+import com.rahman.productservice.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+        classes = ProductServiceApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "spring.cloud.config.fail-fast=false",
+                "spring.cloud.discovery.enabled=false",
+                "eureka.client.enabled=false"
+        }
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("secured-test")
+class CategoryControllerSecuredTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @BeforeEach
+    void setUp() {
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void testSaveCategory_WhenRoleIsUser_ReturnsBadRequest() throws Exception {
+        CreateCategoryRequest request = new CreateCategoryRequest("Electronics", "Electronics", null);
+
+        mockMvc.perform(post("/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testSaveCategory_WhenNotAuthenticated_ReturnsUnauthorized() throws Exception {
+        CreateCategoryRequest request = new CreateCategoryRequest("Electronics", "Electronics", null);
+
+        mockMvc.perform(post("/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void testDeleteCategory_WhenRoleIsUser_ReturnsBadRequest() throws Exception {
+        //Prepare data
+        Category category = new Category();
+        category.setName("Makeup");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+
+        mockMvc.perform(delete("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testDeleteCategory_WhenNotAuthenticated_ReturnsUnauthorized() throws Exception {
+        //Prepare data
+        Category category = new Category();
+        category.setName("Makeup");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+
+        mockMvc.perform(delete("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void testUpdateCategory_WhenRoleIsUser_ReturnsBadRequest() throws Exception {
+        //Prepare data
+        Category category = new Category();
+        category.setName("Makeup");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Electronics", "Electronics", null);
+
+
+        mockMvc.perform(patch("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testUpdateCategory_WhenNotAuthenticated_ReturnsUnauthorized() throws Exception {
+        //Prepare data
+        Category category = new Category();
+        category.setName("Makeup");
+        Category categorySaved = categoryRepository.save(category);
+        UUID id = categorySaved.getId();
+
+
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Electronics", "Electronics", null);
+
+
+        mockMvc.perform(patch("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerTest.java
+++ b/product-service/src/test/java/com/rahman/productservice/controller/CategoryControllerTest.java
@@ -1,0 +1,181 @@
+package com.rahman.productservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rahman.productservice.dto.category.CategorySimpleResponse;
+import com.rahman.productservice.dto.category.CreateCategoryRequest;
+import com.rahman.productservice.dto.category.CategoryResponse;
+import com.rahman.productservice.dto.category.UpdateCategoryRequest;
+import com.rahman.productservice.entity.Category;
+import com.rahman.productservice.exception.ResourceNotFoundException;
+import com.rahman.productservice.mapper.CategoryMapper;
+import com.rahman.productservice.service.CategoryService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "spring.cloud.config.fail-fast=false"
+        }
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CategoryMapper categoryMapper;
+
+    @Autowired
+    private MessageSource messageSource;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testFindAll_ReturnsListOfCategories() throws Exception {
+        // Arrange
+        UUID id = UUID.randomUUID();
+        CategoryResponse category = new CategoryResponse(id, "Apple", "Apple",
+                new CategorySimpleResponse(UUID.randomUUID(), "Electronics"),
+                Instant.now(), Instant.now(), null);
+        when(categoryService.findAll()).thenReturn(List.of(category));
+
+        // Act & Assert
+        mockMvc.perform(get("/category")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("success")))
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id", is(id.toString())))
+                .andExpect(jsonPath("$.data[0].name", is("Apple")))
+                .andExpect(jsonPath("$.data[0].parent.name", is("Electronics")));
+
+        verify(categoryService).findAll();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testSave_ReturnsSuccess() throws Exception {
+        CreateCategoryRequest request = new CreateCategoryRequest("Electronics", "Electronics", null);
+        Category categoryData = new Category();
+        categoryData.setId(UUID.randomUUID());
+        categoryData.setName("Makeup");
+
+        when(categoryService.save(any(CreateCategoryRequest.class))).thenReturn(categoryMapper.toResponse(categoryData));
+
+        mockMvc.perform(post("/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("success")))
+                .andExpect(jsonPath("$.data.name", is("Makeup")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDelete_ReturnSuccess() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("success")))
+                .andExpect(jsonPath("$.data").value(Matchers.nullValue()));
+
+        verify(categoryService).deleteById(id);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDelete_WhenIdNotFound_ReturnNotFound() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        doThrow(new ResourceNotFoundException(messageSource.getMessage("category.not_found", null, LocaleContextHolder.getLocale())))
+                .when(categoryService).deleteById(any(UUID.class));
+
+        mockMvc.perform(delete("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Category not found.")))
+                .andExpect(jsonPath("$.data").value(Matchers.nullValue()));
+
+        verify(categoryService).deleteById(id);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testUpdate_ReturnSuccess() throws Exception {
+        UUID id = UUID.randomUUID();
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Electronics", "Electronics", null);
+        Category categoryData = new Category();
+        categoryData.setId(id);
+        categoryData.setName("Makeup");
+
+        when(categoryService.update(any(UUID.class), any(UpdateCategoryRequest.class))).thenReturn(categoryMapper.toResponse(categoryData));
+
+        mockMvc.perform(patch("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("success")))
+                .andExpect(jsonPath("$.data.id", is(id.toString())))
+                .andExpect(jsonPath("$.data.name", is("Makeup")));
+
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testUpdate_WhenIdNotFound_ReturnNotFound() throws Exception {
+        UUID id = UUID.randomUUID();
+        UpdateCategoryRequest request = new UpdateCategoryRequest("Electronics", "Electronics", null);
+
+        doThrow(new ResourceNotFoundException(messageSource.getMessage("category.not_found", null, LocaleContextHolder.getLocale())))
+                .when(categoryService).update(any(UUID.class), any(UpdateCategoryRequest.class));
+
+        mockMvc.perform(patch("/category/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Category not found.")))
+                .andExpect(jsonPath("$.data").value(Matchers.nullValue()));
+
+        verify(categoryService).update(id, request);
+    }
+}

--- a/product-service/src/test/java/com/rahman/productservice/service/impl/CategoryServiceRedisIntegrationTest.java
+++ b/product-service/src/test/java/com/rahman/productservice/service/impl/CategoryServiceRedisIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.rahman.productservice.service.impl;
+
+import com.rahman.productservice.dto.category.CategoryResponse;
+import com.rahman.productservice.dto.category.CreateCategoryRequest;
+import com.rahman.productservice.dto.category.UpdateCategoryRequest;
+import com.rahman.productservice.entity.Category;
+import com.rahman.productservice.repository.CategoryRepository;
+import com.rahman.productservice.service.CategoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.interceptor.SimpleKey;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CategoryServiceRedisIntegrationTest extends BaseServiceIntegrationTest {
+
+    private static final String CATEGORY_CACHE = "categories";
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @BeforeEach
+    void setup() {
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    void testFindAll_ShouldCacheResult() {
+        // given
+        Category category = new Category();
+        category.setName("Toys");
+        categoryRepository.save(category);
+
+        // when (first call - hits DB)
+        List<CategoryResponse> result1 = categoryService.findAll();
+
+        // then
+        assertThat(result1).hasSize(1);
+        assertThat(result1.getFirst().name()).isEqualTo("Toys");
+
+        // when (second call - should come from cache)
+        List<CategoryResponse> result2 = categoryService.findAll();
+
+        // then: same result & cache must be present
+        assertThat(result2).hasSize(1);
+        assertCachePresent(CATEGORY_CACHE, SimpleKey.EMPTY);
+    }
+
+    @Test
+    void testSave_ShouldPersistEntity_AndEvictCache() {
+        // given
+        categoryService.findAll(); // prime cache
+
+        // when
+        CreateCategoryRequest request = new CreateCategoryRequest("Hobbies", "Hobby and Toys", null);
+        CategoryResponse saved = categoryService.save(request);
+
+        // then
+        assertThat(categoryRepository.findById(saved.id())).isPresent();
+        assertCacheEvicted(CATEGORY_CACHE, SimpleKey.EMPTY);
+    }
+
+    @Test
+    @Transactional
+    void testUpdate_ShouldEvictCacheAndUpdateData() {
+        // given
+        Category category = new Category();
+        category.setName("Gadgets");
+        Category saved = categoryRepository.save(category);
+
+        categoryService.findAll(); // prime cache
+
+        // when
+        UpdateCategoryRequest updateRequest = new UpdateCategoryRequest("Updated Gadgets", "Updated Gadgets", null);
+        CategoryResponse updated = categoryService.update(saved.getId(), updateRequest);
+
+        // then
+        assertThat(updated.name()).isEqualTo("Updated Gadgets");
+        assertThat(categoryRepository.findById(saved.getId())
+                .get()
+                .getName()
+        ).isEqualTo("Updated Gadgets");
+
+        // cache should be evicted
+        assertCacheEvicted(CATEGORY_CACHE, SimpleKey.EMPTY);
+    }
+
+    @Test
+    @Transactional
+    void testDelete_ShouldRemoveEntity_AndEvictCache() {
+        // given
+        Category category = new Category();
+        category.setName("Clothes");
+        Category saved = categoryRepository.save(category);
+
+        categoryService.findAll(); // prime cache
+
+        UUID id = saved.getId();
+
+        // when
+        categoryService.deleteById(id);
+
+        // then
+        assertThat(categoryRepository.findById(id)).isEmpty();
+        assertCacheEvicted(CATEGORY_CACHE, SimpleKey.EMPTY);
+    }
+
+}


### PR DESCRIPTION
- Add caching for Category retrieval and update endpoints
- Integrate cache eviction on create, update, and delete actions
- Optimize CategoryController and service for cache usage
- Update related tests to cover caching scenarios